### PR TITLE
Changed "wrong execution" message in dna.py

### DIFF
--- a/dna/dna.py
+++ b/dna/dna.py
@@ -5,7 +5,7 @@ from cs50 import get_string
 
 # Checking for correct number of command-line arguments
 if len(sys.argv) != 3:
-    sys.exit("Incorrect number of command-line arguments")
+    sys.exit("Usage: python dna.py data.csv sequence.txt")
 
 # Loading data from CSV file into memory as List of Dictionaries
 people = []


### PR DESCRIPTION
Changed message appearing after executing program with wrong arguments to one that provides information about what are the arguments options.